### PR TITLE
Upgrade to oraclelinux OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-
+Python-3.9.0/
+Python-3.9.0.tgz
 *.img
 .DS_Store

--- a/gridlabd_dockerhub_base/Dockerfile
+++ b/gridlabd_dockerhub_base/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8 
+FROM oraclelinux:8.5
 ENV container docker
 
 VOLUME [ "/sys/fs/cgroup" ]


### PR DESCRIPTION
CentOS Linux 8 is decommissioned as of Dec 31, 2021 and the packages are no longer supported. This branch deploys oracle Linux as the open-source alternative to centos 8.